### PR TITLE
[R+M] docs: add link to tutorial

### DIFF
--- a/doc_source/multi-environments.rst
+++ b/doc_source/multi-environments.rst
@@ -21,7 +21,7 @@ Your app now has two deployments available at `https://master.appid.amplifyapp.c
 Team workflows with Amplify CLI backend environments
 ===============================
 
-A feature branch deployment can consist of a **frontend** and [(optionally) a **backend**](https://docs.aws.amazon.com/amplify/latest/userguide/how-to-service-role-amplify-console.html). The frontend is built and deployed to a global CDN, while the backend is deployed by the Amplify CLI to AWS.
+A feature branch deployment can consist of a **frontend** and [(optionally) a **backend**](https://docs.aws.amazon.com/amplify/latest/userguide/deploy-backend.html). The frontend is built and deployed to a global CDN, while the backend is deployed by the Amplify CLI to AWS.
 You can use the Amplify Console to continuously deploy backend resources such as GraphQL APIs and Lambda functions with your feature branch deployment. You can use the following models to deploy your backend and frontend with the Amplify Console:
 
 .. contents::

--- a/doc_source/multi-environments.rst
+++ b/doc_source/multi-environments.rst
@@ -21,7 +21,7 @@ Your app now has two deployments available at `https://master.appid.amplifyapp.c
 Team workflows with Amplify CLI backend environments
 ===============================
 
-A feature branch deployment can consist of a **frontend** and (optionally) a **backend**. The frontend is built and deployed to a global CDN, while the backend is deployed by the Amplify CLI to AWS.
+A feature branch deployment can consist of a **frontend** and [(optionally) a **backend**](https://docs.aws.amazon.com/amplify/latest/userguide/how-to-service-role-amplify-console.html). The frontend is built and deployed to a global CDN, while the backend is deployed by the Amplify CLI to AWS.
 You can use the Amplify Console to continuously deploy backend resources such as GraphQL APIs and Lambda functions with your feature branch deployment. You can use the following models to deploy your backend and frontend with the Amplify Console:
 
 .. contents::


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If following the setup guide, it's not clear that a service role needs to be created which may cause frustration when a build unexpectedly fails.  This PR simply adds a link to the related documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**edit**

The tutorial talks about creating a service role, so updating to direct a user there instead.