### PR TITLE
Escaping a backslash in JSON

### DIFF
--- a/doc_source/redirects.rst
+++ b/doc_source/redirects.rst
@@ -186,7 +186,7 @@ Most SPA frameworks support HTML5 history.pushState() to change browser location
        - :code:`200`
        -
 
-  :superscript:`JSON [{"source": "</^[^.]+$|\.(?!(css|gif|ico|jpg|js|png|txt|svg|woff|ttf|map|json)$)([^.]+$)/>", "status": "200", "target": "index.html", "condition": null}]`
+  :superscript:`JSON [{"source": "</^[^.]+$|\\\\.(?!(css|gif|ico|jpg|js|png|txt|svg|woff|ttf|map|json)$)([^.]+$)/>", "status": "200", "target": "index.html", "condition": null}]`
 
 
 Reverse Proxy Rewrite


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In JSON, you need to escape a backslash (`\`) as `\\`.  In the source Markdown, it must be `\\\\`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
