### PR TITLE
Add detail on skipping build per commit

### DIFF
--- a/doc_source/build-settings.rst
+++ b/doc_source/build-settings.rst
@@ -227,9 +227,15 @@ The **envCache** provides key-value storage at build time. Values stored in the 
       envCache --set <key> <value>
       envCache --get <key>
 
+Skip Build for a Commit
+=====================================
+
+To skip an automatic build on a particular commit, include the text **[skip-cd]** at the end of the commit message.
+
 Disable Automatic builds 
 =====================================
 
 You can configure Amplify Console to disable automatic builds on every code commit. To set up, choose **App settings > General** and then scroll to the section with all the connected branches. Select a branch, and then choose **Action > Disable auto build**. Further commits to that branch will no longer trigger a new build.
 
 .. image:: images/autobuild.png
+


### PR DESCRIPTION
*Description of changes:*

Add note to build settings page on how to skip automatic build for a particular commit by including suffix "[skip-cd]".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
