### PR TITLE
Missing '/' in JSON example

### DIFF
--- a/doc_source/redirects.rst
+++ b/doc_source/redirects.rst
@@ -186,7 +186,7 @@ Most SPA frameworks support HTML5 history.pushState() to change browser location
        - :code:`200`
        -
 
-  :superscript:`JSON [{"source": "</^[^.]+$|\.(?!(css|gif|ico|jpg|js|png|txt|svg|woff|ttf|map|json)$)([^.]+$)/>", "status": "200", "target": "index.html", "condition": null}]`
+  :superscript:`JSON [{"source": "</^[^.]+$|\.(?!(css|gif|ico|jpg|js|png|txt|svg|woff|ttf|map|json)$)([^.]+$)/>", "status": "200", "target": "/index.html", "condition": null}]`
 
 
 Reverse Proxy Rewrite


### PR DESCRIPTION
The '/' is important to make SPA apps work, and the example above has it correctly added in front of index.html, it is just missing in the JSON example

*Issue #, if available:*

*Description of changes:*
Fixing documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
