### PR TITLE
Update Monorepo example

### DIFF
--- a/doc_source/build-settings.md
+++ b/doc_source/build-settings.md
@@ -98,34 +98,122 @@ Monorepos with multiple amplify applications are declared as a list of applicati
 ```
 version: 1
 applications:
-     -  appRoot: /react-app
-        env:
-            variables: []
-        frontend:
-            phases:
-                build:
-                  ...
-            artifacts:
-                files:
-                    - '**/*'
-                baseDirectory: /
-            cache:
-                paths:
-                    - node_modules
-     -  appRoot: /angular-app
-        env:
-            variables: []
-        frontend:
-            phases:
-                build:
-                    ...
-            artifacts:
-                files:
-                    - '**/*'
-                baseDirectory: /
-            cache:
-                paths:
-                    - node_modules
+  - appRoot: /react-app
+    env:
+    variables:
+        key: value
+    backend:
+      phases:
+        preBuild:
+          commands:
+            - *enter command*
+        build:
+          commands:
+            - *enter command*
+        postBuild:
+            commands:
+            - *enter command*
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - *enter command*
+            - *enter command*
+        build:
+          commands:
+            - *enter command*
+      artifacts:
+        files:
+            - location
+            - location
+        discard-paths: yes
+        baseDirectory: location
+      cache:
+        paths:
+            - path
+            - path
+      customHeaders:
+       - pattern: 'file-pattern'
+         headers:
+         - key: 'custom-header-name'
+           value: 'custom-header-value'
+         - key: 'custom-header-name'
+           value: 'custom-header-value'
+    test:
+      phases:
+        preTest:
+          commands:
+            - *enter command*
+        test:
+          commands:
+            - *enter command*
+        postTest:
+          commands:
+            - *enter command*
+      artifacts:
+        files:
+            - location
+            - location
+        configFilePath: *location*
+        baseDirectory: *location*
+  - appRoot: /angular-app
+    env:
+    variables:
+        key: value
+    backend:
+      phases:
+        preBuild:
+          commands:
+            - *enter command*
+        build:
+          commands:
+            - *enter command*
+        postBuild:
+            commands:
+            - *enter command*
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - *enter command*
+            - *enter command*
+        build:
+          commands:
+            - *enter command*
+      artifacts:
+        files:
+            - location
+            - location
+        discard-paths: yes
+        baseDirectory: location
+      cache:
+        paths:
+            - path
+            - path
+      customHeaders:
+       - pattern: 'file-pattern'
+         headers:
+         - key: 'custom-header-name'
+           value: 'custom-header-value'
+         - key: 'custom-header-name'
+           value: 'custom-header-value'
+    test:
+      phases:
+        preTest:
+          commands:
+            - *enter command*
+        test:
+          commands:
+            - *enter command*
+        postTest:
+          commands:
+            - *enter command*
+      artifacts:
+        files:
+            - location
+            - location
+        configFilePath: *location*
+        baseDirectory: *location*
 ```
 
 You must provide the following additional information for each application you declare in your build configuration:


### PR DESCRIPTION
The previous monorepo sample build spec had a very small subset of options displayed.  This might be confusing to customers as they may think that the options for monorepo have been changed or reduced.  I am proposing showing all possible options just as the single app yml does.  I understand that this makes the sample very large.  I am open to suggestions about how to reduce the size.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
