### PR TITLE
Fix order of execution for environment variables npm build example

### DIFF
--- a/doc_source/environment-variables.md
+++ b/doc_source/environment-variables.md
@@ -50,8 +50,8 @@ To access an environment variable during a build, edit your build settings to in
    ```
    build:
      commands:
-       - npm run build:$BUILD_ENV
        - echo "TWITCH_CLIENT_ID=$TWITCH_CLIENT_ID" >> backend/.env
+       - npm run build:$BUILD_ENV
    ```
 
 Each command in your build configuration is executed inside a Bash shell\. For more information on working with environment variables in Bash, see [Shell Expansions](https://www.gnu.org/software/bash/manual/html_node/Shell-Expansions.html#Shell-Expansions) in the GNU Bash Manual\. 


### PR DESCRIPTION
*Issue #, if available: The example in the documentation first build the project then set the environment variables, that causes the env variables to be ignored

*Description of changes:* Change the order of the commands to write the `.env` file then build the project


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
