### PR TITLE
Updated instructions to enable auto subdomains

### DIFF
--- a/doc_source/to-set-up-automatic-subdomains-for-a-Route-53-custom-domain.md
+++ b/doc_source/to-set-up-automatic-subdomains-for-a-Route-53-custom-domain.md
@@ -10,9 +10,11 @@ After an app is connected to a custom domain in Route 53, Amplify Console enabl
 
 1. In the navigation pane, choose **App Settings**, and then choose **Domain management**\.
 
-1. On the **Domain management** page, choose **Edit domain**\.
+1. On the **Domain management** page, choose **Manage subdomains**\.
 
 1. Select the **Sub\-domain auto\-detection** check box on the bottom left side\.
+
+Note: This feature is only available for root domains (i.e. **example.com**). You will not see this check box if your domain is already a subdomain like **dev\.exampledomain\.com**. 
 
 ## Web previews with subdomains<a name="web-previews-on-subdomains"></a>
 


### PR DESCRIPTION
*Description of changes:*
The current instructions say to click the "Edit domain" button but there is no such button in the UI. The correct button to click is "Manage subdomains" and then you can enable the feature from there. Also I added a warning that says this is only possible for root domains.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
