### PR TITLE
Fix Content-Security-Policy; it needs single quote

### DIFF
--- a/doc_source/custom-headers.md
+++ b/doc_source/custom-headers.md
@@ -190,5 +190,5 @@ customHeaders:
       - key: 'X-Content-Type-Options'
         value: 'nosniff'
       - key: 'Content-Security-Policy'
-        value: 'default-src self'
+        value: "default-src 'self'"
 ```


### PR DESCRIPTION
Source https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/default-src#sources

Signed-off-by: FORNO <forno@xmaho.link>

*Description of changes:*
Content-Security-Policy HTTP header needs `'self'`; not `self`.
`self` isn't work. It just need `'self'`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.