### PR TITLE
Fixed wrong syntax in build setting; Added new var

### DIFF
--- a/doc_source/environment-variables.md
+++ b/doc_source/environment-variables.md
@@ -51,7 +51,8 @@ To access an environment variable during a build, edit your build settings to in
    build:
      commands:
        - npm run build:$BUILD_ENV
-       - echo "TWITCH_CLIENT_ID=$TWITCH_CLIENT_ID" >> backend/.env
+        - TWITCH_CLIENT_ID=$TWITCH_CLIENT_ID # or equivalently the line below
+        - VARIABLE_NAME_2=${VARIABLE_NAME_2} # with {} it also works
    ```
 
 Each command in your build configuration is executed inside a Bash shell\. For more information on working with environment variables in Bash, see [Shell Expansions](https://www.gnu.org/software/bash/manual/html_node/Shell-Expansions.html#Shell-Expansions) in the GNU Bash Manual\. 
@@ -113,6 +114,7 @@ You can use the following environment variables that are accessible by default w
 |  AMPLIFY\_SKIP\_BACKEND\_BUILD  |  If you do not have a backend section in your build spec and want to disable backend builds, set this environment variable to `true`\.  | true | 
 |  AMPLIFY\_MONOREPO\_APP\_ROOT  |  The path to use to specify the app root of a monorepo app, relative to the root of your repository\.  | apps/react\-app | 
 |  \_BUILD\_TIMEOUT  |  The build timeout duration in minutes\.  |  30  | 
+|  AWS\_PULL\_REQUEST\_ID  |  The version of auto-generated for pull request\.  | pr-1 | 
 
 **Note**  
 The `AMPLIFY_AMAZON_CLIENT_ID` and `AMPLIFY_AMAZON_CLIENT_SECRET` environment variables are OAuth tokens, not an AWS access key and secret key\. 


### PR DESCRIPTION
*Issue #, if available:*
NONE

*Description of changes:*
First diff, wrong syntax:
My console reported 
```
# Executing command: echo "GH_CLIENT_ID=ABCDEFG" >> backend/.env
[WARNING]: /codebuild/output/src827021234/src/${my-app-name}/amplify.sh: line 23: backend/.env: No such file or directory
````
Second diff, missing ENV VAR:
It's just missing and cannot be searched via google.
https://stackoverflow.com/questions/65054034/aws-amplify-environment-variables-for-pull-requests

Reason (TL;DR):
- On first diff:
This misbehavior is mentioned in many questions
https://stackoverflow.com/questions/64072288/how-to-add-environment-variables-to-aws-amplify
https://stackoverflow.com/questions/66138372/how-to-use-aws-amplify-environment-variables-in-react-app
https://stackoverflow.com/questions/66176973/amplify-save-environment-variables-to-backend/69331262#69331262
- On second diff(AWS\_PULL\_REQUEST\_ID ):
https://stackoverflow.com/questions/65054034/aws-amplify-environment-variables-for-pull-requests

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. But the copyright is reserved.
