### PR TITLE
Update redirects.md - add `webp` to excluded files

### DIFF
--- a/doc_source/redirects.md
+++ b/doc_source/redirects.md
@@ -130,7 +130,7 @@ Most SPA frameworks support HTML5 history\.pushState\(\) to change browser locat
 
 | Original address | Destination Address | Redirect Type | Country Code | 
 | --- | --- | --- | --- | 
-|   `</^[^.]+$\|\.(?!(css\|gif\|ico\|jpg\|js\|png\|txt\|svg\|woff\|woff2\|ttf\|map\|json)$)([^.]+$)/>`   |   `/index.html`   |   `200`   |  | 
+|   `</^[^.]+$\|\.(?!(css\|gif\|ico\|jpg\|js\|png\|txt\|svg\|woff\|woff2\|ttf\|map\|json|webp)$)([^.]+$)/>`   |   `/index.html`   |   `200`   |  | 
 
  JSON \[\{"source": "</^\[^\.\]\+$\|\\\.\(?\!\(css\|gif\|ico\|jpg\|js\|png\|txt\|svg\|woff\|ttf\|map\|json\)$\)\(\[^\.\]\+$\)/>", "status": "200", "target": "index\.html", "condition": null\}\] 
 


### PR DESCRIPTION
When using SPA some images can be saved in `.webp` format (for example it's default in Gatsby), those files should not be redirected to the `index.html` - otherwise they are not loaded on the website.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
