### PR TITLE
added wait-on code sample to use timeout

### DIFF
--- a/doc_source/running-tests.md
+++ b/doc_source/running-tests.md
@@ -22,7 +22,7 @@ test:
         - npm install pm2
         - npm install mocha@5.2.0 mochawesome mochawesome-merge mochawesome-report-generator
         - npx pm2 start npm -- start
-        - 'npx wait-on http://localhost:3000'
+        - 'npx wait-on --timeout 60 http://localhost:3000'
     test:
       commands:
         - 'npx cypress run --reporter mochawesome --reporter-options "reportDir=cypress/report/mochawesome-report,overwrite=false,html=false,json=true,timestamp=mmddyyyy_HHMMss"'


### PR DESCRIPTION
Added `--timeout 60` to the `wait-on` code sample to prevent accidental builds that wait until the 30 minute build limit.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
