### PR TITLE
Improve esbuild command in Troubleshooting SSR deployments section

### DIFF
--- a/doc_source/troubleshooting-ssr-deployment.md
+++ b/doc_source/troubleshooting-ssr-deployment.md
@@ -23,9 +23,10 @@ Currently, the maximum build output size that Amplify supports for Next\.js 12 a
 If you get an error that the size of your build output exceeds the max allowed size, you might be able to reduce the size of your build output using the esbuild JavaScript bundler\. Add the following commands to the build step in your app's `amplify.yml` file\.
 
 ```
-- allfiles=$(ls -al ./.next/standalone/**/*.js)
-- npx esbuild $allfiles --minify --outdir=.next/standalone --platform=node --target=node16 --format=cjs --allow-overwrite
+- find ./.next/standalone -type f -name "*.js" | xargs npx esbuild --minify --outdir=.next/standalone --platform=node --target=node16 --format=cjs --allow-overwrite
 ```
+
+This command first runs the `find` command to search for .js files within the .next/standalone directory and its subdirectories. Then, it pipes the output of the find command to `xargs`, which takes the list of files and passes them as arguments to the `esbuild` command.
 
 ## Your build fails with an out of memory error<a name="out-of-memory"></a>
 


### PR DESCRIPTION
**Issue this solves:**

I use a package called `charts.js`, guess what the output of this is, in relation to the build? (that's the current suggestion the docs give)

`ls -1 ./.next/standalone/**/*.js`

Using `ls` in the context of the documentation is wrong and can lead to such problems. Using find solves this.

**Edits:**

Update Troubleshooting SSR deployments with esbuild command fix.

**Description of changes:**

This PR updates the Troubleshooting SSR deployments section in the documentation. It replaces the previous `ls` command with the `find` command for listing .js files in the .next/standalone directory and its subdirectories. It also uses the `xargs` command to pass the list of files to the esbuild command properly.

These changes ensure that the esbuild command works correctly for minimizing the build output size of Next.js applications deployed with Amplify Hosting.


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
