### PR TITLE
Update deploy-nextjs-app.md

### DIFF
--- a/doc_source/deploy-nextjs-app.md
+++ b/doc_source/deploy-nextjs-app.md
@@ -87,7 +87,7 @@ frontend:
       - node_modules/**/*
 ```
 
-If Amplify detects that you are deploying an SSG app, it generates a buildspec for the app and sets `baseDirectory` to out\. If you are deploying an app where an `amplify.yml` file is present, you must manually set the `baseDirectory` to `out` in the file\.
+If Amplify detects that you are deploying an SSG app, it generates a buildspec for the app and sets `baseDirectory` to `out`\. If you are deploying an app where an `amplify.yml` file is present, you must manually set the `baseDirectory` to `out` in the file\.
 
 The following is an example of the build settings for an app where `baseDirectory` is set to `out`\. This indicates that the build artifacts are for a Next\.js app that supports only SSG pages\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add missing backticks around word "out"

It was not consistent with the rest of the page:
![image](https://user-images.githubusercontent.com/30082936/231773860-fda63644-5181-46c9-b1fe-bdb8b0ca9381.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
